### PR TITLE
Fix IPV6 config syntax

### DIFF
--- a/charts/bind9/Chart.yaml
+++ b/charts/bind9/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: bind9
 description: A Helm chart for Bind9 using the official ISC docker image
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "9.18"

--- a/charts/bind9/templates/secret-named-conf-authoritative.yaml
+++ b/charts/bind9/templates/secret-named-conf-authoritative.yaml
@@ -15,7 +15,7 @@ stringData:
       {{- end }}
       listen-on port 5053 { any; };
       {{ if .Values.authoritative.ipv6_enabled -}}
-      listen-on-v6 5053 { any; };
+      listen-on-v6 port 5053 { any; };
       {{- else -}}
       listen-on-v6 { none; };
       {{- end }}

--- a/charts/bind9/templates/secret-named-conf-resolver.yaml
+++ b/charts/bind9/templates/secret-named-conf-resolver.yaml
@@ -15,7 +15,7 @@ stringData:
       {{- end }}
       listen-on port 5053 { any; };
       {{ if .Values.resolver.ipv6_enabled -}}
-      listen-on-v6 5053 { any; };
+      listen-on-v6 port 5053 { any; };
       {{- else -}}
       listen-on-v6 { none; };
       {{- end }}


### PR DESCRIPTION
This resolves an issue I had trying to get this to run on my k3s cluster. It looks like `listen-on-v6` requires `port <number>` as well according to the [docs](https://bind9.readthedocs.io/en/v9_18_7/reference.html?highlight=listen-on-v6#namedconf-statement-listen-on-v6). 

Using ISC Bind 9.16 explicitly with values:

```
image:
  repository: internetsystemsconsortium/bind9
  pullPolicy: IfNotPresent
  # Overrides the image tag whose default is the chart appVersion.
  tag: "9.16"
```

Error output
```
bind9 16-Oct-2022 21:52:01.060 starting BIND 9.18.7-1+ubuntu22.04.1+isc+1-Ubuntu (Stable Release) <id:>
bind9 16-Oct-2022 21:52:01.060 running on Linux x86_64 5.10.0-18-amd64 #1 SMP Debian 5.10.140-1 (2022-09-02)
bind9 16-Oct-2022 21:52:01.060 built with  '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=${prefix}/include' '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' '--sysconfdir=/etc' '--localstatedir=/var' '--disable-option-checking' '--disable-silent-rules' '--libdir=${prefix}/lib/x86_64-linux-gnu' '--runstatedir=/run' '--disable-maintainer-mode' '--disable-dependency-tracking' '--libdir=/usr/lib/x86_64-linux-gnu' '--sysconfdir=/etc/bind' '--with-python=python3' '--localstatedir=/' '--enable-threads' '--enable-largefile' '--with-libtool' '--enable-shared' '--disable-static' '--with-gost=no' '--with-openssl=/usr' '--with-gssapi=yes' '--with-libidn2' '--with-json-c' '--with-lmdb=/usr' '--with-gnu-ld' '--with-maxminddb' '--with-atf=no' '--enable-ipv6' '--enable-rrl' '--enable-filter-aaaa' '--disable-native-pkcs11' '--enable-dnstap' 'build_alias=x86_64-linux-gnu' 'CFLAGS=-g -O2 -ffile-prefix-map=/build/bind9-E4vWCW/bind9-9.18.7=. -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -fno-strict-aliasing -fno-delete-null-pointer-checks -DNO_VERSION_DATE -DDIG_SIGCHASE' 'LDFLAGS=-Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -flto=auto -Wl,-z,relro -Wl,-z,now' 'CPPFLAGS=-Wdate-time -D_FORTIFY_SOURCE=2'
bind9 16-Oct-2022 21:52:01.060 running as: named -g -c /etc/named/named.conf -u bind
bind9 16-Oct-2022 21:52:01.060 compiled by GCC 11.2.0
bind9 16-Oct-2022 21:52:01.060 compiled with OpenSSL version: OpenSSL 3.0.2 15 Mar 2022
bind9 16-Oct-2022 21:52:01.060 linked to OpenSSL version: OpenSSL 3.0.2 15 Mar 2022
bind9 16-Oct-2022 21:52:01.060 compiled with libxml2 version: 2.9.13
bind9 16-Oct-2022 21:52:01.060 linked to libxml2 version: 20913
bind9 16-Oct-2022 21:52:01.060 compiled with json-c version: 0.15
bind9 16-Oct-2022 21:52:01.060 linked to json-c version: 0.15
bind9 16-Oct-2022 21:52:01.060 compiled with zlib version: 1.2.11
bind9 16-Oct-2022 21:52:01.060 linked to zlib version: 1.2.11
bind9 16-Oct-2022 21:52:01.060 ----------------------------------------------------
bind9 16-Oct-2022 21:52:01.060 BIND 9 is maintained by Internet Systems Consortium,
bind9 16-Oct-2022 21:52:01.060 Inc. (ISC), a non-profit 501(c)(3) public-benefit
bind9 16-Oct-2022 21:52:01.060 corporation.  Support and training for BIND 9 are
bind9 16-Oct-2022 21:52:01.060 available at https://www.isc.org/support
bind9 16-Oct-2022 21:52:01.060 ----------------------------------------------------
bind9 16-Oct-2022 21:52:01.060 found 16 CPUs, using 16 worker threads
bind9 16-Oct-2022 21:52:01.060 using 16 UDP listeners per interface
bind9 16-Oct-2022 21:52:01.116 config.c: option 'trust-anchor-telemetry' is experimental and subject to change in the future
bind9 16-Oct-2022 21:52:01.116 loading configuration from '/etc/named/named.conf'
bind9 16-Oct-2022 21:52:01.116 /etc/named/named.conf:6: unexpected '5053'
bind9 16-Oct-2022 21:52:01.172 loading configuration: unexpected token
bind9 16-Oct-2022 21:52:01.172 exiting (due to fatal error)

````